### PR TITLE
Prevent accidentally adding base currency tx to BagFIFO

### DIFF
--- a/ccgains/bags.py
+++ b/ccgains/bags.py
@@ -440,7 +440,7 @@ class BagFIFO(object):
         self._check_order(dtime)
         exchange = str(exchange).capitalize()
         amount = Decimal(amount)
-        currency = currency.upper()
+        currency = currency.upper()  # self.currency is uppercase
 
         if amount <= 0:
             return
@@ -516,16 +516,15 @@ class BagFIFO(object):
 
         """
         self._check_order(dtime)
-
-        amount = Decimal(amount)
         if amount <= 0: return
-
         exchange = str(exchange).capitalize()
-        currency = currency.upper()
+        currency = currency.upper()  # self.currency is upper.
         if currency == self.currency:
-            self._abort(
-                    'Withdrawing the base currency is not possible.',
-                    CurrencyTypeException)
+            log.warning(
+                "Withdrawing the base currency is not supported and will be "
+                "ignored. If this was not intentional, it could indicate "
+                "using the wrong append...csv() method")
+            return
 
         fee = Decimal(fee)
         if exchange not in self.totals:
@@ -595,16 +594,15 @@ class BagFIFO(object):
 
         """
         self._check_order(dtime)
-
-        amount = Decimal(amount)
         if amount <= 0: return
-
         exchange = str(exchange).capitalize()
-        currency = currency.upper()
+        currency = currency.upper()  # self.currency is already uppercase
         if currency == self.currency:
-            self._abort(
-                'Depositing the base currency is not possible.',
-                CurrencyTypeException)
+            log.warning(
+                "Depositing the base currency is not supported and will "
+                "be ignored. If this was not intentional, it could indicate "
+                "using the wrong append...csv() method")
+            return
 
         fee = Decimal(fee)
 
@@ -742,10 +740,10 @@ class BagFIFO(object):
         fee_ratio = Decimal(fee_ratio)
         if amount <= 0: return
         exchange = str(exchange).capitalize()
-        currency = currency.upper()
+        currency = currency.upper()  # self.currency is already uppercase
         if currency == self.currency:
             self._abort(
-                'Payments with the base currency are not relevant here.',
+                'Payments with the base currency are not supported.',
                 CurrencyTypeException)
         if exchange not in self.bags or not self.bags[exchange]:
             self._abort(

--- a/tests/test_bags.py
+++ b/tests/test_bags.py
@@ -298,6 +298,42 @@ class TestBagFIFO(unittest.TestCase):
             {k:v for k, v in bf2.__dict__.items() if k != 'report'})
         self.assertListEqual(bagfifo.report.data, bf2.report.data)
 
+    def test_no_like_for_like(self):
+        """Test that it is not possible to deposit, withdraw, buy, or pay
+        with the BagFIFO base currency.
+
+        Note: testing against both the new CurrencyTypeException and also ValueError
+        This is in case a future change modifies the order in which arguments are
+        checked in any of these functions, which is not critical in some cases.
+        The point is that none of these should succeed if the BagFIFO base currency
+        (fiat) is used in any transaction instead of expected crypto
+        """
+
+        # Note: 'usd' will be converted to uppercase in the constructor
+        bagfifo = bags.BagFIFO('usd', self.rel)
+
+        assert bagfifo.currency == 'USD'
+
+        # Should not be able to buy
+        with self.subTest(method="buy_with_base_currency"):
+            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
+                bagfifo.buy_with_base_currency(self.rng[0], 10, 'usd', 10, 'Coinbase')
+
+        # Should not be able to withdraw
+        with self.subTest(method="withdraw"):
+            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
+                bagfifo.withdraw(self.rng[1], 'usd', '1', 0, 'Binance')
+
+        # Should not be able to deposit
+        with self.subTest(method="deposit"):
+            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
+                bagfifo.deposit(self.rng[2], 'usd', '5', '0', 'Coinbase')
+
+        # Should not be able to pay
+        with self.subTest(method="pay"):
+            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
+                bagfifo.pay(self.rng[3], 'usd', '1','Coinbase')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bags.py
+++ b/tests/test_bags.py
@@ -319,16 +319,6 @@ class TestBagFIFO(unittest.TestCase):
             with self.assertRaises((bags.CurrencyTypeException, ValueError)):
                 bagfifo.buy_with_base_currency(self.rng[0], 10, 'usd', 10, 'Coinbase')
 
-        # Should not be able to withdraw
-        with self.subTest(method="withdraw"):
-            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
-                bagfifo.withdraw(self.rng[1], 'usd', '1', 0, 'Binance')
-
-        # Should not be able to deposit
-        with self.subTest(method="deposit"):
-            with self.assertRaises((bags.CurrencyTypeException, ValueError)):
-                bagfifo.deposit(self.rng[2], 'usd', '5', '0', 'Coinbase')
-
         # Should not be able to pay
         with self.subTest(method="pay"):
             with self.assertRaises((bags.CurrencyTypeException, ValueError)):


### PR DESCRIPTION
The previous check against using base currency neglected to account for the fact that the BagFIFO converts currency to uppercase, but the affected methods do not convert to uppercase before checking.

Also, found a few instances where amounts were compared to int before being converted from (potentially) string inputs.

(Failing) test cases added in the first commit, and the applicable fixes in the second commit.