### PR TITLE
Refactor CurrencyRelations for readability

### DIFF
--- a/ccgains/historic_data.py
+++ b/ccgains/historic_data.py
@@ -422,7 +422,7 @@ class HistoricDataAPIBinance(HistoricData):
     def __init__(self, cache_folder, unit, interval='H'):
         """Initialize a HistoricData object which will transparently fetch
         data on request (`get_price`) from the public Binance API:
-        https://api.binance.com/api/v1/aggTrades
+        https://api.binance.com/api/v1/klines
 
         For faster loading times on future calls, a HDF5 file is created
         from the requested data and used transparently the next time a

--- a/ccgains/relations.py
+++ b/ccgains/relations.py
@@ -28,170 +28,184 @@ from __future__ import division
 
 from collections import namedtuple
 from functools import total_ordering
-from typing import Dict, List, Tuple
+from typing import List, Tuple, Dict
 
 
 class CurrencyPair(namedtuple("CurrencyPair", ['base', 'quote'])):
     """CurrencyPair(base, quote)"""
 
     def reversed(self):
+        """Swap base(from) for quote(to) currencies"""
         return CurrencyPair(self.quote, self.base)
 
+    def __add__(self, other):
+        if isinstance(other, CurrencyPair):
+            return CurrencyPair(self.base, other.quote)
+        raise NotImplementedError
 
-class RecipeStep:
-    def __init__(self, base, quote, reciprocal):
-        self.base = base
-        self.quote = quote
-        self.reciprocal = reciprocal
+    def __radd__(self, other):
+        if isinstance(other, CurrencyPair):
+            return CurrencyPair(other.base, self.quote)
+
+    def __str__(self):
+        return "<CurrencyPair> ({0.base}, {0.quote})".format(self)
+
+
+@total_ordering
+class Recipe(namedtuple('Recipe', ['num_steps', 'recipe_steps'])):
+    """A conversion recipe made up of `num_steps` steps which are
+    given in `recipe_steps`, showing how to convert from
+    `recipe_steps[0].base` to `recipe_steps[-1].quote`
+    """
+
+    def reversed(self):
+        """A reversed recipe has RecipeSteps in the reversed order,
+        and the opposite value for `reciprocal` for each step
+        """
+
+        reversed_steps = [step.reversed() for step in reversed(self.recipe_steps)]
+        return Recipe(self.num_steps, reversed_steps)
+
+    def __gt__(self, other):
+        """One Recipe is 'greater than' another if it requires more steps"""
+        if isinstance(other, self.__class__):
+            return self.num_steps > other.num_steps
+        raise NotImplementedError
+
+    def __add__(self, other):
+        """Adding an 'other' Recipe involves adding number of steps, and
+        extending the list of recipe steps with the steps in 'other'
+
+        Adding an 'other' Recipe step involves incrementing number of
+        steps by 1, and extending recipe steps with the other RecipeStep
+        """
+
+        if isinstance(other, Recipe):
+            return Recipe(
+                self.num_steps + other.num_steps,
+                self.recipe_steps + other.recipe_steps)
+        elif isinstance(other, RecipeStep):
+            return Recipe(self.num_steps + 1, self.recipe_steps + [other])
+        raise NotImplementedError
+
+    def __radd__(self, other):
+        """Reverse add still increments number of steps, but adds the
+        additional steps on the opposite of the list
+        """
+
+        if isinstance(other, Recipe):
+            return Recipe(
+                self.num_steps + other.num_steps,
+                other.recipe_steps + self.recipe_steps)
+        elif isinstance(other, RecipeStep):
+            return Recipe(self.num_steps + 1, [other] + self.recipe_steps)
+        raise NotImplementedError
+
+
+class RecipeStep(namedtuple('RecipeStep', ['base', 'quote', 'reciprocal'])):
+    """One step in a conversion recipe, indicating base (from) currency,
+    quote (to) currency, and whether the reciprocal of the price should
+    be used for this step.
+    """
 
     def as_recipe(self):
+        """Create a Recipe (with one step) from this RecipeStep"""
         return Recipe(1, [self])
 
     def reversed(self):
         """Return a copy of this recipe step with reciprocal set opposite"""
         return RecipeStep(self.base, self.quote, not self.reciprocal)
 
-    def __getitem__(self, item):
-        if item == 0:
-            return self.base
-        elif item == 1:
-            return self.quote
-        elif item == 2:
-            return self.reciprocal
-        else:
-            raise IndexError
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        elif isinstance(other, tuple):
-            return (self.base, self.quote, self.reciprocal) == other
-        return NotImplemented
-
     def __add__(self, other):
-        if isinstance(other, Recipe):
+        """Adding one RecipeStep to another creates a Recipe.
+
+        Adding a Recipe to a RecipeStep creates a new Recipe with
+        the 'other' Recipe's steps at the end of the new list of
+        recipe steps
+        """
+
+        if type(other) == Recipe:
             return Recipe(other.num_steps + 1, [self] + other.recipe_steps)
-        elif isinstance(other, self.__class__):
+        elif type(other) == self.__class__:
             return Recipe(2, [self, other])
         raise NotImplementedError
 
-
-@total_ordering
-class Recipe:
-    def __init__(self, num_steps: int, recipe_steps: List[RecipeStep]):
-        self.num_steps = num_steps
-        self.recipe_steps = recipe_steps
-
-    def reversed(self):
-        reversed_steps = [step.reversed() for step in reversed(self.recipe_steps)]
-        return Recipe(self.num_steps, reversed_steps)
-
-    def __getitem__(self, item):
-        if item == 0:
-            return self.num_steps
-        elif item == 1:
-            return self.recipe_steps
-        else:
-            raise IndexError
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        elif isinstance(other, tuple):
-            return (self.num_steps, self.recipe_steps) == other
-        return NotImplemented
-
-    def __gt__(self, other):
-        if isinstance(other, self.__class__):
-            return self.num_steps > other.num_steps
-        raise NotImplementedError
-
-    def __add__(self, other):
-        if isinstance(other, self.__class__):
-            return Recipe(self.num_steps + other.num_steps, self.recipe_steps + other.recipe_steps)
-        elif isinstance(other, RecipeStep):
-            return Recipe(self.num_steps + 1, self.recipe_steps + [other])
+    def __radd__(self, other):
+        if type(other) == Recipe:
+            return Recipe(other.num_steps + 1, other.recipe_steps + [self])
+        elif type(other) == self.__class__:
+            return Recipe(2, [other, self])
         raise NotImplementedError
 
 
+# Custom type for static type-checking in a meaningful way
 RecipeDict = Dict[CurrencyPair, Recipe]
 
 
 class CurrencyRelation(object):
+    
     def __init__(self, *args):
-        """Create a CurrencyRelation object. This object contains
-        methods to exchange values between currencies, using
-        historical exchange rates at specific times.
+        """Create a CurrencyRelation object. This object allows
+        exchanging values between currencies, using historical
+        exchange rates at specific times.
 
         :param args:
             Any number of HistoricData objects. If multiple HistoricData
-            objects are given with the same unit, only the last one
-            in the list will be used. More/updated HistoricData
-            objects can be supplied later with `add_historic_data`
-            method.
-
+            objects are given with the same unit, only the last one will
+            be used. More/updated HistoricData objects can be supplied
+            later with `add_historic_data` method.
         """
+
         self.historic_prices = {}
         for hist_data in args:
             key = CurrencyPair(hist_data.cfrom, hist_data.cto)
             self.historic_prices[key] = hist_data
 
-        # self.pairs is a dictionary with keys
-        # `(from_currency, to_currency)` and values
-        # `(num_tsteps, tsteps)` for all pairs of currencies whose
-        # exchange rates can be calculated with the provided historical
-        # data sets. `tsteps` in turn is a list (with length `num_tsteps`)
-        # of `(from_cur, to_cur, reciprocal?)`-tuples with exchanges
-        # directly available in self.hdict that must be applied in
-        # turn (maybe reciprocal) to achieve the desired translation
-        # from `from_currency` to `to_currency`.
         self.recipes = {}  # type: RecipeDict
         self.update_available_pairs()
 
     def add_historic_data(self, hist_data):
         """Add an HistoricData object. If a HistoricData object with
         the same unit has already been added, it will be updated.
-
         """
-        self.historic_prices[CurrencyPair(hist_data.cfrom, hist_data.cto)] = hist_data
-        self.update_available_pairs(CurrencyPair(hist_data.cfrom, hist_data.cto))
 
-    def update_available_pairs(self, newtuple=None):
+        key = CurrencyPair(hist_data.cfrom, hist_data.cto)
+        self.historic_prices[key] = hist_data
+        self.update_available_pairs(key)
+
+    def update_available_pairs(self, update_pair=None):
         """Update internal list of pairs with available historical rate.
 
-        :param newtuple: tuple (from_currency, to_currency);
-            If supplied, updates existing list of pairs (built before)
-            with pair supplied. Default (newtuple=None) will force
-            rebuild of pairs list from scratch based on supplied
-            historical data sets.
-
+        :param update_pair: tuple (from_currency, to_currency);
+            If supplied, updates existing recipes with pair supplied.
+            Default (None) will force rebuild of pairs list from scratch
+            based on supplied historical data sets.
         """
-        if not newtuple:
-            # clear pairs list:
+
+        if not update_pair:
+            # Regenerate all recipes
             self.recipes = {}  # type: RecipeDict
             to_add = list(self.historic_prices.keys())
         else:
-            fcur, tcur = (c.upper() for c in newtuple)
-            # check if newtuple provided is really available:
-            if CurrencyPair(fcur, tcur) not in self.historic_prices:
-                if CurrencyPair(tcur, fcur) not in self.historic_prices:
+            if not isinstance(update_pair, CurrencyPair):
+                update_pair = CurrencyPair(update_pair[0], update_pair[1])
+            # check if update_pair provided is really available:
+            if update_pair not in self.historic_prices:
+                if update_pair.reversed() not in self.historic_prices:
                     raise ValueError(
                         "Supplied new pair {} has no historical data. "
                         "Please provide it with `add_historic_data` first."
-                        "".format(str((fcur, tcur))))
+                        "".format(update_pair))
                 else:
-                    to_add = [CurrencyPair(tcur, fcur)]
+                    to_add = [update_pair.reversed()]
             else:
-                to_add = [CurrencyPair(fcur, tcur)]
-
-        def is_symmetric(first: CurrencyPair, second: CurrencyPair) -> bool:
-            return first.quote == second.base and second.quote == first.base
+                to_add = [update_pair]
 
         def can_add_before(new: CurrencyPair, existing: CurrencyPair) -> bool:
-            return new.quote == existing.base and not is_symmetric(new, existing)
+            return new.quote == existing.base and new != existing.reversed()
 
         def can_add_after(new: CurrencyPair, existing: CurrencyPair) -> bool:
-            return new.base == existing.quote and not is_symmetric(new, existing)
+            return new.base == existing.quote and new != existing.reversed()
 
         def update_if_shorter(pair: CurrencyPair, recipe: Recipe) -> bool:
             if pair not in self.recipes or recipe < self.recipes[pair]:
@@ -201,51 +215,48 @@ class CurrencyRelation(object):
             return False
 
         # Loop through each HistoricPrice
-        for new_base, new_quote in to_add:
-            new_after = []  # type: List[Tuple[CurrencyPair, Recipe]]
-            new_before = []  # type: List[Tuple[CurrencyPair, Recipe]]
+        for root_base, root_quote in to_add:
+            added_after = []  # type: List[Tuple[CurrencyPair, Recipe]]
+            added_before = []  # type: List[Tuple[CurrencyPair, Recipe]]
 
-            single_pair = CurrencyPair(new_base, new_quote)
-            single_step = RecipeStep(single_pair.base, single_pair.quote, False)
+            root_pair = CurrencyPair(root_base, root_quote)
+            root_step = RecipeStep(root_pair.base, root_pair.quote, False)
 
-            for existing_pair, existing_recipe in tuple(self.recipes.items()):
+            for known_pair, known_recipe in tuple(self.recipes.items()):
 
-                if can_add_before(single_pair, existing_pair):
-                    before_pair = CurrencyPair(single_pair.base, existing_pair.quote)
-                    new_recipe = single_step + existing_recipe
+                if can_add_before(root_pair, known_pair):
+                    before_pair = root_pair + known_pair
+                    new_recipe = root_step + known_recipe
 
-                    # If already known, only add if new recipe_steps is shorter:
+                    # If already known, only add if new recipe is shorter:
                     if update_if_shorter(before_pair, new_recipe):
                         # keep track of addition, will be needed later:
-                        new_before.append((existing_pair, existing_recipe))
+                        added_before.append((known_pair, known_recipe))
 
-                elif can_add_after(single_pair, existing_pair):
+                elif can_add_after(root_pair, known_pair):
                     # New pair can be added after existing recipe steps:
-                    new_pair = CurrencyPair(existing_pair.base, single_pair.quote)
-                    new_recipe = existing_recipe + single_step
+                    after_pair = known_pair + root_pair
+                    new_recipe = known_recipe + root_step
 
-                    # If already known, only add if new recipe_steps is shorter:
-                    if update_if_shorter(new_pair, new_recipe):
+                    # If already known, only add if new recipe is shorter:
+                    if update_if_shorter(after_pair, new_recipe):
                         # keep track of addition, will be needed later:
-                        new_after.append((existing_pair, existing_recipe))
+                        added_after.append((known_pair, known_recipe))
 
             # If the new pair could be added to the beginning as well as
             # to the end of existing recipes, there are also new recipes
             # where the new pair joins two old recipes together:
-            for pair_a, recipe_a in new_after:
-                for pair_b, recipe_b in new_before:
+            for pair_a, recipe_a in added_after:
+                for pair_b, recipe_b in added_before:
 
-                    new_pair = CurrencyPair(pair_a.base, pair_b.quote)
-                    new_recipe = recipe_a + single_step + recipe_b
+                    middle_pair = pair_a + pair_b
+                    middle_recipe = recipe_a + root_step + recipe_b
 
-                    # If already known, only add if new recipe_steps is shorter:
-                    update_if_shorter(new_pair, new_recipe)
+                    # If already known, only add if new recipe is shorter:
+                    update_if_shorter(middle_pair, middle_recipe)
 
             # And finally, don't forget to add the new pair by itself:
-            base_recipe = single_step.as_recipe()
-
-            # If already known, only add if new recipe_steps is shorter:
-            update_if_shorter(single_pair, base_recipe)
+            update_if_shorter(root_pair, root_step.as_recipe())
 
         return self.recipes
 
@@ -253,18 +264,18 @@ class CurrencyRelation(object):
         """Return the rate for conversion of *from_currency* to
         *to_currency* at the datetime *dtime*.
 
-        If data for the direct relation of the currency pair has not
-        been added with `add_historic_data` before, an indirect route
-        using multiple added pairs is tried. If this also fails, a
-        KeyError is raised.
+        If a direct relation of the currency pair has not been added with
+        `add_historic_data` before, an indirect route using multiple
+        added pairs is tried. If this also fails, a KeyError is raised.
         """
 
-        recipe_pair = CurrencyPair(from_currency.upper(), to_currency.upper())
-        steps = self.recipes[recipe_pair].recipe_steps
+        key = CurrencyPair(from_currency.upper(), to_currency.upper())
+        steps = self.recipes[key].recipe_steps
         result = 1
         for base_cur, quote_cur, inverse in steps:
+            step_key = CurrencyPair(base_cur, quote_cur)
             if not inverse:
-                result *= self.historic_prices[CurrencyPair(base_cur, quote_cur)].get_price(dtime)
+                result *= self.historic_prices[step_key].get_price(dtime)
             else:
-                result /= self.historic_prices[CurrencyPair(base_cur, quote_cur)].get_price(dtime)
+                result /= self.historic_prices[step_key].get_price(dtime)
         return result

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -29,19 +29,18 @@ from __future__ import division
 import unittest
 
 from ccgains import relations
+from ccgains.relations import CurrencyPair, RecipeStep, Recipe
 
 
 class TestCurrencyRelation(unittest.TestCase):
-
     def setUp(self):
         self.rel = relations.CurrencyRelation()
 
     def test_update_pairs_one(self):
         # Create dummy pairs:
-        pairs = [('A', 'B')]
+        pairs = [("A", "B")]
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)])}
+        d = {("A", "B"): (1, [("A", "B", False)]), ("B", "A"): (1, [("A", "B", True)])}
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -52,12 +51,14 @@ class TestCurrencyRelation(unittest.TestCase):
 
     def test_update_pairs_two_separate(self):
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('C', 'D')]
+        pairs = [("A", "B"), ("C", "D")]
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)]),
-             ('C', 'D'): (1, [('C', 'D', False)]),
-             ('D', 'C'): (1, [('C', 'D', True)])}
+        d = {
+            ("A", "B"): (1, [("A", "B", False)]),
+            ("B", "A"): (1, [("A", "B", True)]),
+            ("C", "D"): (1, [("C", "D", False)]),
+            ("D", "C"): (1, [("C", "D", True)]),
+        }
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -68,14 +69,16 @@ class TestCurrencyRelation(unittest.TestCase):
 
     def test_update_pairs_two_joined(self):
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('B', 'C')]
+        pairs = [("A", "B"), ("B", "C")]
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)]),
-             ('B', 'C'): (1, [('B', 'C', False)]),
-             ('C', 'B'): (1, [('B', 'C', True)]),
-             ('A', 'C'): (2, [('A', 'B', False), ('B', 'C', False)]),
-             ('C', 'A'): (2, [('B', 'C', True), ('A', 'B', True)])}
+        d = {
+            ("A", "B"): (1, [("A", "B", False)]),
+            ("B", "A"): (1, [("A", "B", True)]),
+            ("B", "C"): (1, [("B", "C", False)]),
+            ("C", "B"): (1, [("B", "C", True)]),
+            ("A", "C"): (2, [("A", "B", False), ("B", "C", False)]),
+            ("C", "A"): (2, [("B", "C", True), ("A", "B", True)]),
+        }
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -86,14 +89,16 @@ class TestCurrencyRelation(unittest.TestCase):
 
     def test_update_pairs_two_joinedreverse(self):
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('C', 'B')]
+        pairs = [("A", "B"), ("C", "B")]
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)]),
-             ('C', 'B'): (1, [('C', 'B', False)]),
-             ('B', 'C'): (1, [('C', 'B', True)]),
-             ('A', 'C'): (2, [('A', 'B', False), ('C', 'B', True)]),
-             ('C', 'A'): (2, [('C', 'B', False), ('A', 'B', True)])}
+        d = {
+            ("A", "B"): (1, [("A", "B", False)]),
+            ("B", "A"): (1, [("A", "B", True)]),
+            ("C", "B"): (1, [("C", "B", False)]),
+            ("B", "C"): (1, [("C", "B", True)]),
+            ("A", "C"): (2, [("A", "B", False), ("C", "B", True)]),
+            ("C", "A"): (2, [("C", "B", False), ("A", "B", True)]),
+        }
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -108,24 +113,25 @@ class TestCurrencyRelation(unittest.TestCase):
         self.maxDiff = None
 
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('C', 'D')]
-        pair_extra = ('B', 'C')
+        pairs = [("A", "B"), ("C", "D")]
+        pair_extra = ("B", "C")
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)]),
-             ('C', 'D'): (1, [('C', 'D', False)]),
-             ('D', 'C'): (1, [('C', 'D', True)])}
+        d = {
+            ("A", "B"): (1, [("A", "B", False)]),
+            ("B", "A"): (1, [("A", "B", True)]),
+            ("C", "D"): (1, [("C", "D", False)]),
+            ("D", "C"): (1, [("C", "D", True)]),
+        }
         d_extra = {
-             ('B', 'C'): (1, [('B', 'C', False)]),
-             ('C', 'B'): (1, [('B', 'C', True)]),
-             ('A', 'C'): (2, [('A', 'B', False), ('B', 'C', False)]),
-             ('C', 'A'): (2, [('B', 'C', True), ('A', 'B', True)]),
-             ('B', 'D'): (2, [('B', 'C', False), ('C', 'D', False)]),
-             ('D', 'B'): (2, [('C', 'D', True), ('B', 'C', True)]),
-             ('A', 'D'): (3,
-                 [('A', 'B', False), ('B', 'C', False), ('C', 'D', False)]),
-             ('D', 'A'): (3,
-                 [('C', 'D', True), ('B', 'C', True), ('A', 'B', True)])}
+            ("B", "C"): (1, [("B", "C", False)]),
+            ("C", "B"): (1, [("B", "C", True)]),
+            ("A", "C"): (2, [("A", "B", False), ("B", "C", False)]),
+            ("C", "A"): (2, [("B", "C", True), ("A", "B", True)]),
+            ("B", "D"): (2, [("B", "C", False), ("C", "D", False)]),
+            ("D", "B"): (2, [("C", "D", True), ("B", "C", True)]),
+            ("A", "D"): (3, [("A", "B", False), ("B", "C", False), ("C", "D", False)]),
+            ("D", "A"): (3, [("C", "D", True), ("B", "C", True), ("A", "B", True)]),
+        }
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -150,24 +156,25 @@ class TestCurrencyRelation(unittest.TestCase):
         self.maxDiff = None
 
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('C', 'D')]
-        pair_extra = ('C', 'B')
+        pairs = [("A", "B"), ("C", "D")]
+        pair_extra = ("C", "B")
         # Expected result:
-        d = {('A', 'B'): (1, [('A', 'B', False)]),
-             ('B', 'A'): (1, [('A', 'B', True)]),
-             ('C', 'D'): (1, [('C', 'D', False)]),
-             ('D', 'C'): (1, [('C', 'D', True)])}
+        d = {
+            ("A", "B"): (1, [("A", "B", False)]),
+            ("B", "A"): (1, [("A", "B", True)]),
+            ("C", "D"): (1, [("C", "D", False)]),
+            ("D", "C"): (1, [("C", "D", True)]),
+        }
         d_extra = {
-             ('B', 'C'): (1, [('C', 'B', True)]),
-             ('C', 'B'): (1, [('C', 'B', False)]),
-             ('A', 'C'): (2, [('A', 'B', False), ('C', 'B', True)]),
-             ('C', 'A'): (2, [('C', 'B', False), ('A', 'B', True)]),
-             ('B', 'D'): (2, [('C', 'B', True), ('C', 'D', False)]),
-             ('D', 'B'): (2, [('C', 'D', True), ('C', 'B', False)]),
-             ('A', 'D'): (3,
-                 [('A', 'B', False), ('C', 'B', True), ('C', 'D', False)]),
-             ('D', 'A'): (3,
-                 [('C', 'D', True), ('C', 'B', False), ('A', 'B', True)])}
+            ("B", "C"): (1, [("C", "B", True)]),
+            ("C", "B"): (1, [("C", "B", False)]),
+            ("A", "C"): (2, [("A", "B", False), ("C", "B", True)]),
+            ("C", "A"): (2, [("C", "B", False), ("A", "B", True)]),
+            ("B", "D"): (2, [("C", "B", True), ("C", "D", False)]),
+            ("D", "B"): (2, [("C", "D", True), ("C", "B", False)]),
+            ("A", "D"): (3, [("A", "B", False), ("C", "B", True), ("C", "D", False)]),
+            ("D", "A"): (3, [("C", "D", True), ("C", "B", False), ("A", "B", True)]),
+        }
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -188,8 +195,8 @@ class TestCurrencyRelation(unittest.TestCase):
 
     def test_update_pairs_two_separate_then_joined_then_optimized(self):
         # Create dummy pairs:
-        pairs = [('A', 'B'), ('C', 'D')]
-        pair_extra = ('B', 'C')
+        pairs = [("A", "B"), ("C", "D")]
+        pair_extra = ("B", "C")
 
         # Make dummy historic data dict:
         for p in pairs:
@@ -201,17 +208,180 @@ class TestCurrencyRelation(unittest.TestCase):
         self.rel.add_historic_data(self)
 
         # add pair with direct exchange rate data:
-        direct_pair = ('A', 'D')
+        direct_pair = ("A", "D")
         self.cfrom, self.cto = direct_pair
         self.rel.add_historic_data(self)
 
-        self.assertEqual(
-                self.rel.recipes[direct_pair],
-                (1, [('A', 'D', False)]))
-        self.assertEqual(
-                self.rel.recipes[direct_pair[::-1]],
-                (1, [('A', 'D', True)]))
+        self.assertEqual(self.rel.recipes[direct_pair], (1, [("A", "D", False)]))
+        self.assertEqual(self.rel.recipes[direct_pair[::-1]], (1, [("A", "D", True)]))
 
 
-if __name__ == '__main__':
+class TestRelationCustomTypes(unittest.TestCase):
+    def test_currency_pair_reverse(self):
+        """Test reversing a CurrencyPair results in base and quote swapped"""
+        pair = CurrencyPair("BTC", "USD")
+        expected_reversed_pair = CurrencyPair("USD", "BTC")
+
+        self.assertEqual(pair.reversed(), expected_reversed_pair)
+
+    def test_currency_pair_add(self):
+        """Test that adding one CurrencyPair to another results in a CurrencyPair
+        with (first.base, second.quote)
+        """
+        first = CurrencyPair("XRP", "BTC")
+        second = CurrencyPair("BTC", "USD")
+        expected_pair = CurrencyPair("XRP", "USD")
+        self.assertEqual(first + second, expected_pair)
+
+    def test_currency_pair_immutable_and_hashable(self):
+        """CurrencyPairs are used as dictionary keys, so must be hashable
+        and immutable. Hashes of two equal CurrencyPairs must be equal
+        """
+        pair = CurrencyPair("XRP", "BTC")
+        second_pair = CurrencyPair("XRP", "BTC")
+        first_hash = hash(pair)
+
+        with self.assertRaises(AttributeError):
+            pair.base = "ETH"
+
+        self.assertEqual(hash(pair), first_hash)
+
+        self.assertEqual(pair, second_pair)
+
+        self.assertEqual(hash(pair), hash(second_pair))
+
+    def test_recipe_step_to_recipe(self):
+        """Test that a RecipeStep can be turned into a correct Recipe"""
+        step = RecipeStep("XLM", "ETH", False)
+        recipe = step.as_recipe()
+        expected_recipe = Recipe(1, [RecipeStep("XLM", "ETH", False)])
+
+        self.assertEqual(recipe, expected_recipe)
+
+    def test_recipe_step_reversal(self):
+        """Reversing a RecipeStep should invert the reciprocal and leave currency
+        ordering intact
+        """
+
+        step = RecipeStep("ZEC", "BNB", False)
+        expected_reversed = RecipeStep("ZEC", "BNB", True)
+        self.assertEqual(step.reversed(), expected_reversed)
+
+    def test_add_recipe_steps(self):
+        """Adding two recipe steps should result in a Recipe with correct order"""
+        step_one = RecipeStep("ZEC", "BNB", False)
+        step_two = RecipeStep("BNB", "BTC", False)
+        expected_recipe = Recipe(
+            2, [RecipeStep("ZEC", "BNB", False), RecipeStep("BNB", "BTC", False)]
+        )
+
+        self.assertEqual(step_one + step_two, expected_recipe)
+
+    def test_add_recipe_step_to_recipe(self):
+        """Adding a RecipeStep to a Recipe should put the step in the correct location
+        and increment the number of steps
+        """
+
+        step = RecipeStep("ZEC", "BNB", False)
+        recipe = Recipe(
+            2, [RecipeStep("BNB", "BTC", False), RecipeStep("BTC", "USD", False)]
+        )
+
+        # RecipeStep + Recipe
+        expected_add_right = Recipe(
+            3,
+            [
+                RecipeStep("ZEC", "BNB", False),
+                RecipeStep("BNB", "BTC", False),
+                RecipeStep("BTC", "USD", False),
+            ],
+        )
+
+        # Recipe + RecipeStep
+        expected_add_left = Recipe(
+            3,
+            [
+                RecipeStep("BNB", "BTC", False),
+                RecipeStep("BTC", "USD", False),
+                RecipeStep("ZEC", "BNB", False),
+            ],
+        )
+
+        self.assertEqual(step + recipe, expected_add_right)
+        self.assertEqual(recipe + step, expected_add_left)
+
+    def test_recipe_comparisons(self):
+        """Test comparison operators on Recipes. GT/LT are based on number of steps.
+        Equality requires same number of steps and same list (including ordering) of
+        each step
+        """
+
+        smaller_recipe = Recipe(
+            2, [RecipeStep("BNB", "BTC", False), RecipeStep("BTC", "USD", False)]
+        )
+
+        bigger_recipe = Recipe(
+            3,
+            [
+                RecipeStep("BNB", "BTC", False),
+                RecipeStep("BTC", "USD", False),
+                RecipeStep("ZEC", "BNB", False),
+            ],
+        )
+        bigger_recipe_different_order = Recipe(
+            3,
+            [
+                RecipeStep("BTC", "USD", False),
+                RecipeStep("BNB", "BTC", False),
+                RecipeStep("ZEC", "BNB", False),
+            ],
+        )
+
+        self.assertLess(smaller_recipe, bigger_recipe)
+        self.assertGreater(bigger_recipe, smaller_recipe)
+        self.assertNotEqual(bigger_recipe, bigger_recipe_different_order)
+
+    def test_add_recipe_to_recipe(self):
+        """Recipe + Recipe should give a new recipe with steps in order"""
+        recipe_one = Recipe(
+            2, [RecipeStep("BNB", "BTC", False), RecipeStep("BTC", "USD", False)]
+        )
+        recipe_two = Recipe(
+            3,
+            [
+                RecipeStep("BNB", "BTC", False),
+                RecipeStep("BTC", "USD", False),
+                RecipeStep("ZEC", "BNB", False),
+            ],
+        )
+
+        # one + two
+        expected_add_right = Recipe(
+            5,
+            [
+                RecipeStep("BNB", "BTC", False),  # recipe_one
+                RecipeStep("BTC", "USD", False),  # recipe_one
+                RecipeStep("BNB", "BTC", False),  # recipe_two
+                RecipeStep("BTC", "USD", False),  # recipe_two
+                RecipeStep("ZEC", "BNB", False),  # recipe_two
+            ],
+        )
+
+        # two + one
+        expected_add_left = Recipe(
+            5,
+            [
+                RecipeStep("BNB", "BTC", False),  # recipe_two
+                RecipeStep("BTC", "USD", False),  # recipe_two
+                RecipeStep("ZEC", "BNB", False),  # recipe_two
+                RecipeStep("BNB", "BTC", False),  # recipe_one
+                RecipeStep("BTC", "USD", False),  # recipe_one
+            ],
+        )
+
+        self.assertEqual(recipe_one + recipe_two, expected_add_right)
+        self.assertEqual(recipe_two + recipe_one, expected_add_left)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -30,6 +30,7 @@ import unittest
 
 from ccgains import relations
 
+
 class TestCurrencyRelation(unittest.TestCase):
 
     def setUp(self):
@@ -44,10 +45,10 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
     def test_update_pairs_two_separate(self):
         # Create dummy pairs:
@@ -60,10 +61,10 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
     def test_update_pairs_two_joined(self):
         # Create dummy pairs:
@@ -78,10 +79,10 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
     def test_update_pairs_two_joinedreverse(self):
         # Create dummy pairs:
@@ -96,10 +97,10 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
     def test_update_pairs_two_separate_then_joined(self):
         # Diff for this test case might be long. Disable length constraint:
@@ -128,17 +129,17 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
         # make this a dummy HistoricData object:
         self.cfrom, self.cto = pair_extra
         self.rel.add_historic_data(self)
 
         d.update(d_extra)
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
         # If everything went well, reset maxDiff:
         self.maxDiff = oldmaxDiff
@@ -170,17 +171,17 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
         # make this a dummy HistoricData object:
         self.cfrom, self.cto = pair_extra
         self.rel.add_historic_data(self)
 
         d.update(d_extra)
-        self.assertDictEqual(self.rel.pairs, d)
+        self.assertDictEqual(self.rel.recipes, d)
 
         # If everything went well, reset maxDiff:
         self.maxDiff = oldmaxDiff
@@ -192,7 +193,7 @@ class TestCurrencyRelation(unittest.TestCase):
 
         # Make dummy historic data dict:
         for p in pairs:
-            self.rel.hdict[p] = None
+            self.rel.historic_prices[p] = None
         self.rel.update_available_pairs()
 
         # make this a dummy HistoricData object:
@@ -204,11 +205,11 @@ class TestCurrencyRelation(unittest.TestCase):
         self.cfrom, self.cto = direct_pair
         self.rel.add_historic_data(self)
 
-        self.assertTupleEqual(
-                self.rel.pairs[direct_pair],
+        self.assertEqual(
+                self.rel.recipes[direct_pair],
                 (1, [('A', 'D', False)]))
-        self.assertTupleEqual(
-                self.rel.pairs[direct_pair[::-1]],
+        self.assertEqual(
+                self.rel.recipes[direct_pair[::-1]],
                 (1, [('A', 'D', True)]))
 
 


### PR DESCRIPTION
I spent a while trying to figure out exactly how you were generating the 'recipes' for CurrencyRelation objects, and ended up with a pretty thorough refactor as I was working my way through it.

I think it reads better, and allows for a bit easier testing in the end. There's no change in functionality, and all of the original tests pass in both cases. I added a few more tests for some of the specific changes I made as well.

It clocks in at ~170 extra LOC, but operation time should be almost identical (fractionally slower because of some function overhead). The new classes are all subclasses of NamedTuple, and are just as lightweight as plain tuples. In my opinion, the extra readability is worth it, but up to you, and happy to hear any feedback.

I did use a different nomenclature for currencies in a pair than you've used elsewhere: base/quote currencies instead of from/to currencies. To me, this is less confusing and aligns better with standard financial terminology, but if it's a sticking point I can change it back relatively easily.

Regards,
Anson